### PR TITLE
Add Penny Twitch streamer skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,42 @@
+# Penny V9
+
+Penny is a sarcastic AI-powered Twitch streamer. This repository contains a FastAPI backend and a React frontend. Penny listens to Twitch chat, responds using OpenAI, and speaks through a local Piper TTS engine.
+
+## Running
+
+1. Install Python dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+2. Install frontend dependencies:
+
+```bash
+cd frontend && npm install
+```
+
+3. Set environment variables in a `.env` file:
+
+```
+OPENAI_API_KEY=your_key
+TWITCH_OAUTH_TOKEN=oauth:token
+TWITCH_CHANNEL=yourchannel
+TWITCH_CLIENT_ID=client_id
+TWITCH_CLIENT_SECRET=client_secret
+TWITCH_CHANNEL_ID=channel_id
+```
+
+4. Start the backend:
+
+```bash
+uvicorn backend.main:app --reload
+```
+
+5. Start the frontend:
+
+```bash
+npm run dev
+```
+
+The frontend shows chat messages, Twitch events, and console logs. Use the input box to talk to Penny.

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,13 +1,20 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, BackgroundTasks
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
-from backend.services import personality_engine
-import openai
+from backend.services import (
+    personality_engine,
+    tts_service,
+    mood_service,
+    twitch_chat,
+    twitch_eventsub,
+)
+from shared.event_bus import event_bus
 from openai import OpenAI
 import os
 from dotenv import load_dotenv
 
 load_dotenv()
+
 app = FastAPI()
 
 app.add_middleware(
@@ -18,27 +25,53 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+
 class SpeakRequest(BaseModel):
     text: str
 
+
 client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
 
-@app.post("/api/speak")
-def speak(req: SpeakRequest):
-    prompt = personality_engine.inject_personality(req.text)
 
+@app.on_event("startup")
+async def startup_event():
+    twitch_chat.start_bot()
+    twitch_eventsub.start_eventsub()
+    event_bus.add_log("Backend started")
+
+
+@app.post("/api/speak")
+def speak(req: SpeakRequest, background_tasks: BackgroundTasks):
+    prompt = personality_engine.inject_personality(req.text, mood_service.get_mood())
     try:
         response = client.chat.completions.create(
-            model="gpt-4",  # or "gpt-3.5-turbo"
+            model="gpt-4",
             messages=[
                 {"role": "system", "content": "You are Penny, a snarky but sweet AI streamer assistant."},
-                {"role": "user", "content": prompt}
+                {"role": "user", "content": prompt},
             ],
             temperature=0.9,
             max_tokens=200,
         )
         reply = response.choices[0].message.content
+        background_tasks.add_task(tts_service.speak, reply)
+        event_bus.add_log(f"Penny: {reply}")
         return {"response": reply}
-
     except Exception as e:
+        event_bus.add_log(f"OpenAI error: {e}")
         return {"error": str(e)}
+
+
+@app.get("/api/chat")
+def get_chat():
+    return {"messages": event_bus.get_chats()}
+
+
+@app.get("/api/events")
+def get_events():
+    return {"events": event_bus.get_events()}
+
+
+@app.get("/api/logs")
+def get_logs():
+    return {"logs": event_bus.get_logs()}

--- a/backend/services/mood_service.py
+++ b/backend/services/mood_service.py
@@ -1,0 +1,15 @@
+from shared.event_bus import event_bus
+
+MOODS = ["neutral", "snarky"]
+current_mood = "neutral"
+
+
+def set_mood(mood: str):
+    global current_mood
+    if mood in MOODS:
+        current_mood = mood
+        event_bus.add_log(f"Mood set to {mood}")
+
+
+def get_mood() -> str:
+    return current_mood

--- a/backend/services/response_queue.py
+++ b/backend/services/response_queue.py
@@ -1,0 +1,22 @@
+from collections import deque
+from threading import Lock
+
+class ResponseQueue:
+    def __init__(self, maxlen: int = 100):
+        self._queue = deque(maxlen=maxlen)
+        self._lock = Lock()
+
+    def push(self, item: str) -> None:
+        with self._lock:
+            self._queue.append(item)
+
+    def pop(self):
+        with self._lock:
+            if self._queue:
+                return self._queue.popleft()
+
+    def items(self):
+        with self._lock:
+            return list(self._queue)
+
+response_queue = ResponseQueue()

--- a/backend/services/tts_service.py
+++ b/backend/services/tts_service.py
@@ -1,0 +1,27 @@
+import subprocess
+from pathlib import Path
+from uuid import uuid4
+from shared.event_bus import event_bus
+
+VOICE_MODEL = "en_US-amy-low.onnx"  # Adjust as needed
+
+
+def speak(text: str):
+    """Use piper TTS to speak the given text."""
+    try:
+        tmp = Path("/tmp") / f"piper_{uuid4().hex}.wav"
+        subprocess.run([
+            "piper",
+            "-m",
+            VOICE_MODEL,
+            "-f",
+            str(tmp),
+            "-t",
+            text,
+        ], check=True)
+        # Play via ffplay to VAC or audio device
+        subprocess.run(["ffplay", "-nodisp", "-autoexit", str(tmp)], check=True)
+        tmp.unlink(missing_ok=True)
+        event_bus.add_log(f"Spoke: {text}")
+    except Exception as e:
+        event_bus.add_log(f"TTS error: {e}")

--- a/backend/services/twitch_chat.py
+++ b/backend/services/twitch_chat.py
@@ -1,0 +1,31 @@
+import asyncio
+import os
+from twitchio import Client
+from shared.event_bus import event_bus
+
+TOKEN = os.getenv("TWITCH_OAUTH_TOKEN")
+CHANNEL = os.getenv("TWITCH_CHANNEL")
+
+
+class TwitchBot(Client):
+    def __init__(self):
+        super().__init__(token=TOKEN)
+
+    async def event_ready(self):
+        event_bus.add_log("Connected to Twitch chat")
+        if CHANNEL:
+            await self.join_channels([CHANNEL])
+
+    async def event_message(self, message):
+        if message.echo:
+            return
+        event_bus.add_chat(f"{message.author.name}: {message.content}")
+
+
+def start_bot():
+    if not TOKEN or not CHANNEL:
+        event_bus.add_log("Twitch credentials not configured")
+        return
+    bot = TwitchBot()
+    loop = asyncio.get_event_loop()
+    loop.create_task(bot.start())

--- a/backend/services/twitch_eventsub.py
+++ b/backend/services/twitch_eventsub.py
@@ -1,0 +1,19 @@
+import os
+from twitchAPI.twitch import Twitch
+from shared.event_bus import event_bus
+
+CLIENT_ID = os.getenv("TWITCH_CLIENT_ID")
+CLIENT_SECRET = os.getenv("TWITCH_CLIENT_SECRET")
+CHANNEL_ID = os.getenv("TWITCH_CHANNEL_ID")
+
+
+def start_eventsub():
+    try:
+        if not CLIENT_ID or not CLIENT_SECRET or not CHANNEL_ID:
+            event_bus.add_log("EventSub credentials not configured")
+            return
+        twitch = Twitch(CLIENT_ID, CLIENT_SECRET)
+        twitch.authenticate_app([])
+        event_bus.add_event("EventSub connected")
+    except Exception as e:
+        event_bus.add_log(f"EventSub error: {e}")

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,28 +1,65 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import axios from 'axios'
 import './App.css'
 
 function App() {
-  const [text, setText] = useState("")
+  const [text, setText] = useState('')
   const [response, setResponse] = useState(null)
+  const [chat, setChat] = useState([])
+  const [events, setEvents] = useState([])
+  const [logs, setLogs] = useState([])
 
   const sendToPenny = async () => {
-  const res = await axios.post("/api/speak", { text })
-  setResponse(res.data.response || res.data.error)
-  setText("")
-}
+    const res = await axios.post('/api/speak', { text })
+    setResponse(res.data.response || res.data.error)
+    setText('')
+  }
+
+  useEffect(() => {
+    const i = setInterval(async () => {
+      const c = await axios.get('/api/chat')
+      setChat(c.data.messages)
+      const e = await axios.get('/api/events')
+      setEvents(e.data.events)
+      const l = await axios.get('/api/logs')
+      setLogs(l.data.logs)
+    }, 2000)
+    return () => clearInterval(i)
+  }, [])
 
   return (
-    <div style={{ padding: "2rem", fontFamily: "Arial" }}>
-      <h1>Penny V9 Control Panel</h1>
-      <input
-        style={{ width: "300px", marginRight: "10px" }}
-        value={text}
-        onChange={e => setText(e.target.value)}
-        placeholder="Tell Penny something"
-      />
-      <button onClick={sendToPenny}>Send</button>
-      {response && <p>Penny got: <strong>{response}</strong></p>}
+    <div style={{ padding: '2rem', fontFamily: 'Arial' }}>
+      <h1>Penny Control Panel</h1>
+      <div style={{ marginBottom: '1rem' }}>
+        <input
+          style={{ width: '300px', marginRight: '10px' }}
+          value={text}
+          onChange={e => setText(e.target.value)}
+          placeholder='Tell Penny something'
+        />
+        <button onClick={sendToPenny}>Send</button>
+        {response && <p>Penny said: <strong>{response}</strong></p>}
+      </div>
+      <div style={{ display: 'flex', gap: '1rem' }}>
+        <div style={{ flex: 1 }}>
+          <h2>Chat</h2>
+          <div style={{ border: '1px solid #ccc', height: '200px', overflow: 'auto' }}>
+            {chat.map((m, i) => <div key={i}>{m}</div>)}
+          </div>
+        </div>
+        <div style={{ flex: 1 }}>
+          <h2>Events</h2>
+          <div style={{ border: '1px solid #ccc', height: '200px', overflow: 'auto' }}>
+            {events.map((e, i) => <div key={i}>{e}</div>)}
+          </div>
+        </div>
+        <div style={{ flex: 1 }}>
+          <h2>Console</h2>
+          <div style={{ border: '1px solid #ccc', height: '200px', overflow: 'auto' }}>
+            {logs.map((l, i) => <div key={i}>{l}</div>)}
+          </div>
+        </div>
+      </div>
     </div>
   )
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+fastapi
+uvicorn
+python-dotenv
+openai
+twitchio
+twitchAPI

--- a/shared/event_bus.py
+++ b/shared/event_bus.py
@@ -1,0 +1,35 @@
+from collections import deque
+from threading import Lock
+
+class EventBus:
+    def __init__(self, maxlen: int = 100):
+        self.chat_messages = deque(maxlen=maxlen)
+        self.events = deque(maxlen=maxlen)
+        self.logs = deque(maxlen=maxlen)
+        self._lock = Lock()
+
+    def add_chat(self, message: str) -> None:
+        with self._lock:
+            self.chat_messages.append(message)
+
+    def add_event(self, event: str) -> None:
+        with self._lock:
+            self.events.append(event)
+
+    def add_log(self, log: str) -> None:
+        with self._lock:
+            self.logs.append(log)
+
+    def get_chats(self):
+        with self._lock:
+            return list(self.chat_messages)
+
+    def get_events(self):
+        with self._lock:
+            return list(self.events)
+
+    def get_logs(self):
+        with self._lock:
+            return list(self.logs)
+
+event_bus = EventBus()


### PR DESCRIPTION
## Summary
- implement backend functionality for speaking, twitch chat, events, and logging
- add shared event bus for chat, events and logs
- implement TTS via Piper, mood and response queues
- expand React UI with chat, events and console panels
- document run instructions

## Testing
- `python -m py_compile backend/main.py backend/services/*.py shared/event_bus.py`
- `cd frontend && npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688a53c3d6888325835d332ec1620d94